### PR TITLE
Response to Issue #27: Clarify MUST ignore requirement for unknown parameters

### DIFF
--- a/draft-sheurich-acme-dns-persist.md
+++ b/draft-sheurich-acme-dns-persist.md
@@ -163,7 +163,11 @@ The RDATA of this TXT record MUST fulfill the following requirements:
 
 3.  The issue-value MUST contain an accounturi parameter. The value of this parameter MUST be a unique URI identifying the account of the applicant which requested the validation, constructed according to {{!RFC8657}}, Section 3.
 
-4.  The issue-value MAY contain a `policy` parameter. If present, this parameter modifies the validation scope. The `policy` parameter follows the `key=value` syntax. The policy parameter key and its defined values MUST be treated as case-insensitive. CAs MUST ignore any unknown parameter keys. The following value for the `policy` parameter is defined with respect to subdomain and wildcard validation:
+4.  The issue-value MAY contain a `policy` parameter. If present, this parameter modifies the validation scope. The `policy` parameter follows the `key=value` syntax. The policy parameter key and its defined values MUST be treated as case-insensitive. CAs MUST ignore any unknown parameter keys.
+
+    Note: This requirement ensures forward compatibility, allowing future extensions without breaking existing implementations, consistent with ACME's extensibility model (RFC 8555, Section 7.3). The explicit requirement is necessary to ensure consistent behavior across implementations; without it, some CAs might reject unknown parameters, preventing protocol evolution.
+
+    The following value for the `policy` parameter is defined with respect to subdomain and wildcard validation:
 
     - `policy=wildcard`: If this value is present, the CA MAY consider this validation sufficient for issuing certificates for the validated FQDN, for specific subdomains of the validated FQDN (as covered by wildcard scope or specific subdomain validation rules), and for wildcard certificates (e.g., `*.example.com`). See {{wildcard-certificate-validation}} and {{subdomain-certificate-validation}}.
 
@@ -295,6 +299,8 @@ For a persistent TXT record provisioned at `_validation-persist.example.com` wit
 - Not permitted without additional validation: `otherexample.com`, `example.net`
 
 # Security Considerations {#security-considerations}
+
+The requirement for CAs to ignore unknown parameter keys means that future extensions must be carefully designed to ensure that being ignored does not create security vulnerabilities. Extensions that require strict enforcement should use alternative mechanisms, such as separate record types or explicit version negotiation.
 
 ## Persistent Record Risks {#persistent-record-risks}
 
@@ -430,6 +436,8 @@ IANA is requested to register the following entry in the "ACME Validation Method
 - **Reference**: This document
 
 # Implementation Considerations {#implementation-considerations}
+
+When designing future extensions to this specification, new parameters SHOULD be designed to degrade gracefully when ignored by CAs that do not recognize them. Parameters that fundamentally change the security properties of the validation SHOULD NOT be introduced without a version negotiation mechanism.
 
 ## DNS Record Size Considerations
 

--- a/draft-sheurich-acme-dns-persist.md
+++ b/draft-sheurich-acme-dns-persist.md
@@ -157,7 +157,7 @@ For example, if the domain being validated is "example.com", the Authorization D
 
 The RDATA of this TXT record MUST fulfill the following requirements:
 
-1.  The RDATA value MUST conform to the issue-value syntax as defined in {{!RFC8659}}, Section 4. CAs MUST ignore any unknown parameter keys.
+1.  The RDATA value MUST conform to the issue-value syntax defined in {{!RFC8659}}, Section 4. To ensure forward compatibility, the server MUST ignore any parameter within the issue-value that has an unrecognized tag.
 
 2.  The `issuer-domain-name` portion of the issue-value MUST be one of the Issuer Domain Names provided by the CA in the `issuer-domain-names` array of the challenge object.
 

--- a/draft-sheurich-acme-dns-persist.md
+++ b/draft-sheurich-acme-dns-persist.md
@@ -163,7 +163,7 @@ The RDATA of this TXT record MUST fulfill the following requirements:
 
 3.  The issue-value MUST contain an accounturi parameter. The value of this parameter MUST be a unique URI identifying the account of the applicant which requested the validation, constructed according to {{!RFC8657}}, Section 3.
 
-4.  The issue-value MAY contain a `policy` parameter. If present, this parameter modifies the validation scope. The `policy` parameter follows the `key=value` syntax. The policy parameter key and its defined values MUST be treated as case-insensitive.
+4.  The issue-value MAY contain a `policy` parameter. If present, this parameter modifies the validation scope. The `policy` parameter follows the 'tag=value' syntax from {{!RFC8659}}. The parameter's 'tag' and its defined values MUST be treated as case-insensitive.
 
     Note: This requirement ensures forward compatibility, allowing future extensions without breaking existing implementations, consistent with ACME's extensibility model (RFC 8555, Section 7.3). The explicit requirement is necessary to ensure consistent behavior across implementations; without it, some CAs might reject unknown parameters, preventing protocol evolution.
 
@@ -300,7 +300,7 @@ For a persistent TXT record provisioned at `_validation-persist.example.com` wit
 
 # Security Considerations {#security-considerations}
 
-The requirement for CAs to ignore unknown parameter keys means that future extensions must be carefully designed to ensure that being ignored does not create security vulnerabilities. Extensions that require strict enforcement should use alternative mechanisms, such as separate record types or explicit version negotiation.
+The requirement for CAs to ignore unknown parameter tags means that future extensions must be carefully designed to ensure that being ignored does not create security vulnerabilities. Extensions that require strict enforcement should use alternative mechanisms, such as separate record types or explicit version negotiation.
 
 ## Persistent Record Risks {#persistent-record-risks}
 

--- a/draft-sheurich-acme-dns-persist.md
+++ b/draft-sheurich-acme-dns-persist.md
@@ -157,13 +157,13 @@ For example, if the domain being validated is "example.com", the Authorization D
 
 The RDATA of this TXT record MUST fulfill the following requirements:
 
-1.  The RDATA value MUST conform to the issue-value syntax as defined in {{!RFC8659}}, Section 4.
+1.  The RDATA value MUST conform to the issue-value syntax as defined in {{!RFC8659}}, Section 4. CAs MUST ignore any unknown parameter keys.
 
 2.  The `issuer-domain-name` portion of the issue-value MUST be one of the Issuer Domain Names provided by the CA in the `issuer-domain-names` array of the challenge object.
 
 3.  The issue-value MUST contain an accounturi parameter. The value of this parameter MUST be a unique URI identifying the account of the applicant which requested the validation, constructed according to {{!RFC8657}}, Section 3.
 
-4.  The issue-value MAY contain a `policy` parameter. If present, this parameter modifies the validation scope. The `policy` parameter follows the `key=value` syntax. The policy parameter key and its defined values MUST be treated as case-insensitive. CAs MUST ignore any unknown parameter keys.
+4.  The issue-value MAY contain a `policy` parameter. If present, this parameter modifies the validation scope. The `policy` parameter follows the `key=value` syntax. The policy parameter key and its defined values MUST be treated as case-insensitive.
 
     Note: This requirement ensures forward compatibility, allowing future extensions without breaking existing implementations, consistent with ACME's extensibility model (RFC 8555, Section 7.3). The explicit requirement is necessary to ensure consistent behavior across implementations; without it, some CAs might reject unknown parameters, preventing protocol evolution.
 


### PR DESCRIPTION
This PR addresses Issue #27 regarding the requirement that CAs MUST ignore any unknown parameter keys.

## Key Rationale for Maintaining MUST Ignore Approach

### 1. RFC 8555 Precedent
The ACME protocol (RFC 8555) establishes this pattern in multiple contexts, including:
- Unknown fields in objects (Section 6.2)
- Unknown challenge types
- Unknown identifiers
This creates a consistent pattern across ACME specifications.

### 2. Forward Compatibility
The MUST ignore requirement ensures:
- Future extensions can add new parameters without breaking existing implementations
- Graceful evolution of the protocol without version negotiation
- Smooth deployment of new features

### 3. Operational Simplicity
- Avoids the complexity of a critical key system
- Reduces implementation burden on CAs
- Prevents unnecessary failures for harmless unknown parameters
- Simplifies client-server interactions

## Changes
- The requirement to ignore unknown parameters is clarified to include the rationale (forward compatibility) and to specify "the server" as the actor.
- The term "parameter key(s)" has been replaced with the more precise term "tag(s)" throughout the document, consistent with RFC 8659.
- A direct reference to the `tag=value` syntax in RFC 8659 has been added to improve clarity at the point of first use.

Closes #27